### PR TITLE
fix(@nestjs/event-emitter): Consume events from controllers.

### DIFF
--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -28,7 +28,8 @@ export class EventSubscribersLoader
 
   loadEventListeners() {
     const providers = this.discoveryService.getProviders();
-    providers
+    const controllers = this.discoveryService.getControllers();
+    [...providers, ...controllers]
       .filter(wrapper => wrapper.isDependencyTreeStatic())
       .filter(wrapper => wrapper.instance)
       .forEach((wrapper: InstanceWrapper) => {

--- a/tests/e2e/module-e2e.spec.ts
+++ b/tests/e2e/module-e2e.spec.ts
@@ -1,7 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../src/app.module';
-import { EventsConsumer } from '../src/events.consumer';
+import { EventsControllerConsumer } from '../src/events-controller.consumer';
+import { EventsProviderConsumer } from '../src/events-provider.consumer';
 
 describe('EventEmitterModule - e2e', () => {
   let app: INestApplication;
@@ -14,8 +15,15 @@ describe('EventEmitterModule - e2e', () => {
     app = module.createNestApplication();
   });
 
-  it(`should emit a "test-event" event`, async () => {
-    const eventsConsumerRef = app.get(EventsConsumer);
+  it(`should emit a "test-event" event to providers`, async () => {
+    const eventsConsumerRef = app.get(EventsProviderConsumer);
+    await app.init();
+
+    expect(eventsConsumerRef.eventPayload).toEqual({ test: 'event' });
+  });
+
+  it(`should emit a "test-event" event to controllers`, async () => {
+    const eventsConsumerRef = app.get(EventsControllerConsumer);
     await app.init();
 
     expect(eventsConsumerRef.eventPayload).toEqual({ test: 'event' });

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '../../lib';
-import { EventsConsumer } from './events.consumer';
+import { EventsControllerConsumer } from './events-controller.consumer';
+import { EventsProviderConsumer } from './events-provider.consumer';
 import { EventsProducer } from './events.producer';
 
 @Module({
@@ -9,6 +10,7 @@ import { EventsProducer } from './events.producer';
       wildcard: true,
     }),
   ],
-  providers: [EventsConsumer, EventsProducer],
+  controllers: [EventsControllerConsumer],
+  providers: [EventsProviderConsumer, EventsProducer],
 })
 export class AppModule {}

--- a/tests/src/events-controller.consumer.ts
+++ b/tests/src/events-controller.consumer.ts
@@ -1,0 +1,12 @@
+import { Controller, Injectable } from '@nestjs/common';
+import { OnEvent } from '../../lib';
+
+@Controller()
+export class EventsControllerConsumer {
+  public eventPayload = {};
+
+  @OnEvent('test.*')
+  onTestEvent(payload: Record<string, any>) {
+    this.eventPayload = payload;
+  }
+}

--- a/tests/src/events-provider.consumer.ts
+++ b/tests/src/events-provider.consumer.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { OnEvent } from '../../lib';
 
 @Injectable()
-export class EventsConsumer {
+export class EventsProviderConsumer {
   public eventPayload = {};
 
   @OnEvent('test.*')


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
   - Docs haven't been added, but the [documentation](https://docs.nestjs.com/techniques/events) doesn't specify where events can be consumed from.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

We cannot consume events from controllers. Due to the lack of documentation specifying that only providers can consume events, I am fearful that members of the community who become confused when their events aren't consumed will entirely drop their use of this really neat package.

Issue Number: N/A


## What is the new behavior?

We can consume events from controllers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information