### PR TITLE
feat: support option to prepend event listener

### DIFF
--- a/lib/decorators/on-event.decorator.ts
+++ b/lib/decorators/on-event.decorator.ts
@@ -1,6 +1,6 @@
 import { SetMetadata } from '@nestjs/common';
-import { OnOptions } from 'eventemitter2';
 import { EVENT_LISTENER_METADATA } from '../constants';
+import { OnEventOptions } from '../interfaces';
 
 /**
  * `@OnEvent` decorator metadata
@@ -13,7 +13,7 @@ export interface OnEventMetadata {
   /**
    * Subscription options.
    */
-  options?: OnOptions;
+  options?: OnEventOptions;
 }
 
 /**
@@ -24,6 +24,6 @@ export interface OnEventMetadata {
  */
 export const OnEvent = (
   event: string | symbol | Array<string | symbol>,
-  options?: OnOptions,
+  options?: OnEventOptions,
 ): MethodDecorator =>
   SetMetadata(EVENT_LISTENER_METADATA, { event, options } as OnEventMetadata);

--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -57,7 +57,11 @@ export class EventSubscribersLoader
       return;
     }
     const { event, options } = eventListenerMetadata;
-    this.eventEmitter.on(
+    const listenerMethod = !!options?.prependListener
+      ? this.eventEmitter.prependListener.bind(this.eventEmitter)
+      : this.eventEmitter.on.bind(this.eventEmitter);
+
+    listenerMethod(
       event,
       (...args: unknown[]) => instance[methodKey].call(instance, ...args),
       options,

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './event-emitter-options.interface';
+export * from './on-event-options.interface';

--- a/lib/interfaces/on-event-options.interface.ts
+++ b/lib/interfaces/on-event-options.interface.ts
@@ -1,0 +1,12 @@
+import { OnOptions } from 'eventemitter2';
+
+export type OnEventOptions = OnOptions & {
+  /**
+   * If "true", prepends (instead of append) the given listener to the array of listeners.
+   *
+   * @see https://github.com/EventEmitter2/EventEmitter2#emitterprependlistenerevent-listener-options
+   *
+   * @default false
+   */
+  prependListener?: boolean;
+};

--- a/tests/e2e/module-e2e.spec.ts
+++ b/tests/e2e/module-e2e.spec.ts
@@ -1,7 +1,9 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { EventEmitter2 } from 'eventemitter2';
 import { AppModule } from '../src/app.module';
 import { EventsControllerConsumer } from '../src/events-controller.consumer';
+import { EventsProviderPrependConsumer } from '../src/events-provider-prepend.consumer';
 import { EventsProviderConsumer } from '../src/events-provider.consumer';
 
 describe('EventEmitterModule - e2e', () => {
@@ -28,6 +30,15 @@ describe('EventEmitterModule - e2e', () => {
 
     expect(eventsConsumerRef.eventPayload).toEqual({ test: 'event' });
   });
+
+  it('should be able to specify a consumer be prepended via OnEvent decorator options', async () => {
+    const eventsConsumerRef = app.get(EventsProviderPrependConsumer);
+    const prependListenerSpy = jest.spyOn(app.get(EventEmitter2), 'prependListener');
+    await app.init();
+
+    expect(eventsConsumerRef.eventPayload).toEqual({ test: 'event' });
+    expect(prependListenerSpy).toHaveBeenCalled();
+  })
 
   afterEach(async () => {
     await app.close();

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '../../lib';
 import { EventsControllerConsumer } from './events-controller.consumer';
+import { EventsProviderPrependConsumer } from './events-provider-prepend.consumer';
 import { EventsProviderConsumer } from './events-provider.consumer';
 import { EventsProducer } from './events.producer';
 
@@ -11,6 +12,6 @@ import { EventsProducer } from './events.producer';
     }),
   ],
   controllers: [EventsControllerConsumer],
-  providers: [EventsProviderConsumer, EventsProducer],
+  providers: [EventsProviderConsumer, EventsProviderPrependConsumer, EventsProducer],
 })
 export class AppModule {}

--- a/tests/src/events-provider-prepend.consumer.ts
+++ b/tests/src/events-provider-prepend.consumer.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '../../lib';
+
+@Injectable()
+export class EventsProviderPrependConsumer {
+  public eventPayload = {};
+
+  @OnEvent('test.*', { prependListener: true })
+  onTestEvent(payload: Record<string, any>) {
+    this.eventPayload = payload;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #401


## What is the new behavior?
Supports a new, optional`prependListener` boolean option within the `OnEvent` decorator. When set to `true` the `prependListener` method on EventEmitter2 will be called instead of `on`.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
