### PR TITLE
feat: add suppress errors option

### DIFF
--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -95,7 +95,7 @@ export class EventSubscribersLoader
         listenerMethod(
           event,
           (...args: unknown[]) =>
-            this.wrapFunctionInTryCatchBlocks(instance, methodKey, args),
+            this.wrapFunctionInTryCatchBlocks(instance, methodKey, args, options),
           options,
         );
       }
@@ -142,6 +142,7 @@ export class EventSubscribersLoader
           contextInstance,
           listenerMethodKey,
           args,
+          options,
         );
       },
       options,
@@ -177,11 +178,16 @@ export class EventSubscribersLoader
     instance: Record<string, any>,
     methodKey: string,
     args: unknown[],
+    options?: OnEventOptions,
   ) {
     try {
       return await instance[methodKey].call(instance, ...args);
     } catch (e) {
-      this.logger.error(e);
+      if (options?.suppressErrors ?? true) {
+        this.logger.error(e);
+      } else {
+        throw e;
+      }
     }
   }
 }

--- a/lib/interfaces/on-event-options.interface.ts
+++ b/lib/interfaces/on-event-options.interface.ts
@@ -9,4 +9,11 @@ export type OnEventOptions = OnOptions & {
    * @default false
    */
   prependListener?: boolean;
+
+  /**
+   * If "true", the onEvent callback will not throw an error while handling the event. Otherwise, if "false" it will throw an error.
+   * 
+   * @default true
+   */
+  suppressErrors?: boolean;
 };

--- a/tests/e2e/module-e2e.spec.ts
+++ b/tests/e2e/module-e2e.spec.ts
@@ -133,6 +133,17 @@ describe('EventEmitterModule - e2e', () => {
     expect(result).toBeTruthy();
   });
 
+  it('should be able to gracefully recover when an unexpected error occurs from provider and suppressErrors is true', async () => {
+    const eventsConsumerRef = app.get(EventsProviderConsumer);
+    await app.init();
+
+    const emitter = app.get(EventEmitter2);
+    const result = emitter.emit('error-handling-suppressed.provider');
+
+    expect(eventsConsumerRef.errorHandlingCalls).toEqual(1);
+    expect(result).toBeTruthy();
+  });
+
   it('should be able to gracefully recover when an unexpected error occurs from request scoped', async () => {
     await app.init();
 
@@ -140,6 +151,29 @@ describe('EventEmitterModule - e2e', () => {
     const result = eventEmitter.emit('error-handling.request-scoped');
 
     expect(result).toBeTruthy();
+  });
+
+  it('should be able to gracefully recover when an unexpected error occurs from request scoped and suppressErrors is true', async () => {
+    await app.init();
+
+    const eventEmitter = app.get(EventEmitter2);
+    const result = eventEmitter.emit('error-handling-suppressed.request-scoped');
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should throw when an unexpected error occurs from provider and suppressErrors is false', async () => {
+    await app.init();
+
+    const eventEmitter = app.get(EventEmitter2);
+    expect(eventEmitter.emitAsync('error-throwing.provider')).rejects.toThrow("This is a test error");
+  });
+
+  it('should throw when an unexpected error occurs from request scoped and suppressErrors is false', async () => {
+    await app.init();
+
+    const eventEmitter = app.get(EventEmitter2);
+    expect(eventEmitter.emitAsync('error-throwing.request-scoped')).rejects.toThrow("This is a test error");
   });
 
   afterEach(async () => {

--- a/tests/src/events-provider.consumer.ts
+++ b/tests/src/events-provider.consumer.ts
@@ -23,4 +23,15 @@ export class EventsProviderConsumer {
     this.errorHandlingCalls++;
     throw new Error('This is a test error');
   }
+
+  @OnEvent('error-handling-suppressed.provider', { suppressErrors: true })
+  onErrorHandlingSuppressedEvent() {
+    this.errorHandlingCalls++;
+    throw new Error('This is a test error');
+  }
+
+  @OnEvent('error-throwing.provider', { suppressErrors: false })
+  onErrorThrowingEvent() {
+    throw new Error('This is a test error');
+  }
 }

--- a/tests/src/events-provider.request-scoped.consumer.ts
+++ b/tests/src/events-provider.request-scoped.consumer.ts
@@ -26,4 +26,14 @@ export class EventsProviderRequestScopedConsumer {
   onErrorHandlingEvent() {
     throw new Error('This is a test error');
   }
+
+  @OnEvent('error-handling-suppressed.request-scoped', { suppressErrors: true })
+  onErrorHandlingSuppressedEvent() {
+    throw new Error('This is a test error');
+  }
+
+  @OnEvent('error-throwing.request-scoped', { suppressErrors: false })
+  onErrorThrowingEvent() {
+    throw new Error('This is a test error');
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The new version of event-emitter 2.0.1 suppress all errors by default, as described here: https://github.com/nestjs/event-emitter/issues/932.

Issue Number: https://github.com/nestjs/event-emitter/issues/934

## What is the new behavior?
Included a new option to `OnEvent` decorator to disable `suppressErrors`, so it will be possible to get errors from failed listeners. The default value is `true`, so, if is not disabled the behavior will be keep as the same as today.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
