### PR TITLE
fix(@nestjs/event-emitter): Circumvent crash in reflect-metadata

### DIFF
--- a/lib/events-metadata.accessor.ts
+++ b/lib/events-metadata.accessor.ts
@@ -13,7 +13,7 @@ export class EventsMetadataAccessor {
     // Circumvent a crash that comes from reflect-metadata if it is
     // given a non-object non-function target to reflect upon.
     if (
-      target === undefined ||
+      !target ||
       (typeof target !== 'function' && typeof target !== 'object')
     ) {
       return undefined;

--- a/lib/events-metadata.accessor.ts
+++ b/lib/events-metadata.accessor.ts
@@ -10,6 +10,15 @@ export class EventsMetadataAccessor {
   getEventHandlerMetadata(
     target: Type<unknown>,
   ): OnEventMetadata[] | undefined {
+    // Circumvent a crash that comes from reflect-metadata if it is
+    // given a non-object non-function target to reflect upon.
+    if (
+      target === undefined ||
+      (typeof target !== 'function' && typeof target !== 'object')
+    ) {
+      return undefined;
+    }
+
     const metadata = this.reflector.get(EVENT_LISTENER_METADATA, target);
     if (!metadata) {
       return undefined;


### PR DESCRIPTION
This fixes #1008 by circumventing the situation where reflect-metadata would be given a value that was neither a function nor an object because the event-emitter was somehow tricked into traversing it as if it were. E.G. by being given a Proxy wrapping and removing some keys of a class.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

If the above (tests and doc changes) are required for a minor fix like this, please let me know and give me guidance on how to provide them. This cannot be tested in the e2e framework currently provided, but I could add a new unit test for this one function if required.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1008

Currently crashes if iterating over the target yields a non-function non-object value.

## What is the new behavior?

Not crashing - instead it silently skips the key in question.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
