### PR TITLE
feat: event emitter durable listener

### DIFF
--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -17,6 +17,7 @@ import { EventEmitter2 } from 'eventemitter2';
 import { EventEmitterReadinessWatcher } from './event-emitter-readiness.watcher';
 import { EventsMetadataAccessor } from './events-metadata.accessor';
 import { OnEventOptions } from './interfaces';
+import { EventRequestObject } from './interfaces/event-request-object.interface';
 
 @Injectable()
 export class EventSubscribersLoader
@@ -138,7 +139,9 @@ export class EventSubscribersLoader
       event,
       async (...args: unknown[]) => {
         const request = this.getRequestFromEventPayload(args);
-        const contextId = ContextIdFactory.getByRequest({ payload: request });
+        const contextId = ContextIdFactory.getByRequest<
+          EventRequestObject<unknown>
+        >({ payload: request });
 
         this.moduleRef.registerRequestByContextId(request, contextId);
 

--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -17,7 +17,7 @@ import { EventEmitter2 } from 'eventemitter2';
 import { EventEmitterReadinessWatcher } from './event-emitter-readiness.watcher';
 import { EventsMetadataAccessor } from './events-metadata.accessor';
 import { OnEventOptions } from './interfaces';
-import { EventRequestObject } from './interfaces/event-request-object.interface';
+import { EventPayloadHost } from './interfaces/event-payload-host.interface';
 
 @Injectable()
 export class EventSubscribersLoader
@@ -140,7 +140,7 @@ export class EventSubscribersLoader
       async (...args: unknown[]) => {
         const request = this.getRequestFromEventPayload(args);
         const contextId = ContextIdFactory.getByRequest<
-          EventRequestObject<unknown>
+          EventPayloadHost<unknown>
         >({ payload: request });
 
         this.moduleRef.registerRequestByContextId(request, contextId);

--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -11,10 +11,7 @@ import {
   ModuleRef,
 } from '@nestjs/core';
 import { Injector } from '@nestjs/core/injector/injector';
-import {
-  ContextId,
-  InstanceWrapper,
-} from '@nestjs/core/injector/instance-wrapper';
+import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { EventEmitter2 } from 'eventemitter2';
 import { EventEmitterReadinessWatcher } from './event-emitter-readiness.watcher';
@@ -140,9 +137,10 @@ export class EventSubscribersLoader
     listenerMethod(
       event,
       async (...args: unknown[]) => {
-        const contextId = ContextIdFactory.create();
+        const request = this.getRequestFromEventPayload(args);
+        const contextId = ContextIdFactory.getByRequest({ payload: request });
 
-        this.registerEventPayloadByContextId(args, contextId);
+        this.moduleRef.registerRequestByContextId(request, contextId);
 
         const contextInstance = await this.injector.loadPerContext(
           eventListenerInstance,
@@ -161,10 +159,7 @@ export class EventSubscribersLoader
     );
   }
 
-  private registerEventPayloadByContextId(
-    eventPayload: unknown[],
-    contextId: ContextId,
-  ) {
+  private getRequestFromEventPayload(eventPayload: unknown[]): unknown {
     /*
       **Required explanation for the ternary below**
 
@@ -179,11 +174,7 @@ export class EventSubscribersLoader
       However, whoever is using this library would certainly expect the event payload to be a single string 'payload', not an array,
       since this is what we emitted above.
     */
-
-    const payloadObjectOrArray =
-      eventPayload.length > 1 ? eventPayload : eventPayload[0];
-
-    this.moduleRef.registerRequestByContextId(payloadObjectOrArray, contextId);
+    return eventPayload.length > 1 ? eventPayload : eventPayload[0];
   }
 
   private async wrapFunctionInTryCatchBlocks(

--- a/lib/interfaces/event-payload-host.interface.ts
+++ b/lib/interfaces/event-payload-host.interface.ts
@@ -1,0 +1,3 @@
+export type EventPayloadHost<T> = {
+  payload: T;
+};

--- a/lib/interfaces/event-request-object.interface.ts
+++ b/lib/interfaces/event-request-object.interface.ts
@@ -1,3 +1,0 @@
-export type EventRequestObject<T> = {
-  payload: T;
-};

--- a/lib/interfaces/event-request-object.interface.ts
+++ b/lib/interfaces/event-request-object.interface.ts
@@ -1,0 +1,3 @@
+export type EventRequestObject<T> = {
+  payload: T;
+};

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,3 +1,3 @@
 export * from './event-emitter-options.interface';
 export * from './on-event-options.interface';
-export * from './event-request-object.interface';
+export * from './event-payload-host.interface';

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './event-emitter-options.interface';
 export * from './on-event-options.interface';
+export * from './event-request-object.interface';

--- a/tests/e2e/module-e2e.spec.ts
+++ b/tests/e2e/module-e2e.spec.ts
@@ -247,14 +247,6 @@ describe('EventEmitterModule - e2e', () => {
     expect(durableInstance).toBe(durableInstance2);
   });
 
-  it('should load durable provider once for different event emissions', async () => {
-    await app.init();
-    const eventEmitter = app.get(EventEmitter2);
-    const [durableInstance] = await eventEmitter.emitAsync('durable');
-    const [durableInstance2] = await eventEmitter.emitAsync('durable');
-    expect(durableInstance).toBe(durableInstance2);
-  });
-
   it('should load non-durable provider anew for different event emissions', async () => {
     await app.init();
     const eventEmitter = app.get(EventEmitter2);

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -5,6 +5,7 @@ import { EventsControllerConsumer } from './events-controller.consumer';
 import { EventsProviderAliasedConsumer } from './events-provider-aliased.consumer';
 import { EventsProviderPrependConsumer } from './events-provider-prepend.consumer';
 import { EventsProviderConsumer } from './events-provider.consumer';
+import { EventsProviderDurableRequestScopedConsumer } from './events-provider.durable-request-scoped.consumer';
 import { EventsProviderRequestScopedConsumer } from './events-provider.request-scoped.consumer';
 import { EventsProducer } from './events.producer';
 import { TestProvider } from './test-provider';
@@ -22,6 +23,7 @@ import { TestProvider } from './test-provider';
     EventsProducer,
     TestProvider,
     EventsProviderRequestScopedConsumer,
+    EventsProviderDurableRequestScopedConsumer,
     EventsProviderAliasedConsumer,
     {
       provide: 'AnAliasedConsumer',

--- a/tests/src/events-provider.durable-request-scoped.consumer.ts
+++ b/tests/src/events-provider.durable-request-scoped.consumer.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { OnEvent } from '../../lib';
+import { EVENT_PAYLOAD } from '../../lib';
+import { RequestScopedEventPayload } from './request-scoped-event-payload';
+
+@Injectable({ scope: Scope.REQUEST, durable: true })
+export class EventsProviderDurableRequestScopedConsumer {
+  constructor(@Inject(EVENT_PAYLOAD) public eventRef: any) {}
+
+  public static injectedEventPayload = new RequestScopedEventPayload();
+
+  private transformPayload = (payload: unknown[]) =>
+    payload.length === 1 ? payload[0] : payload;
+
+  @OnEvent('test.*')
+  onTestEvent(...payload: unknown[]) {
+    EventsProviderDurableRequestScopedConsumer.injectedEventPayload.setPayload(
+      this.transformPayload(payload),
+    );
+  }
+
+  @OnEvent('multiple.*')
+  onMultiplePayloadEvent(...payload: unknown[]) {
+    EventsProviderDurableRequestScopedConsumer.injectedEventPayload.setPayload(
+      this.transformPayload(payload),
+    );
+  }
+
+  @OnEvent('string.*')
+  onStringPayloadEvent(payload: string) {
+    EventsProviderDurableRequestScopedConsumer.injectedEventPayload.setPayload(
+      payload,
+    );
+  }
+
+  @OnEvent('error-handling.durable-request-scoped')
+  onErrorHandlingEvent() {
+    throw new Error('This is a test error');
+  }
+
+  @OnEvent('error-handling-suppressed.durable-request-scoped', {
+    suppressErrors: true,
+  })
+  onErrorHandlingSuppressedEvent() {
+    throw new Error('This is a test error');
+  }
+
+  @OnEvent('error-throwing.durable-request-scoped', { suppressErrors: false })
+  onErrorThrowingEvent() {
+    throw new Error('This is a test error');
+  }
+
+  @OnEvent('durable')
+  onDurableTest() {
+    return this;
+  }
+}

--- a/tests/src/events-provider.request-scoped.consumer.ts
+++ b/tests/src/events-provider.request-scoped.consumer.ts
@@ -36,4 +36,9 @@ export class EventsProviderRequestScopedConsumer {
   onErrorThrowingEvent() {
     throw new Error('This is a test error');
   }
+
+  @OnEvent('not-durable')
+  onDurableTest() {
+    return this;
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
https://github.com/nestjs/event-emitter/issues/1247

## What is the new behavior?
Durable injectable with declared subscribers will be loaded as durable.
Context strategy will use the event payload as the request object for the context strategy.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Existing request subscribers within durable injectables will now fail to load unless the context strategy can resolve based on the payload, unlike before, where they simply behaved as non-durable.

## Other information
