### PR TITLE
fix: provide separate event emitter instance per each app instance

### DIFF
--- a/lib/event-emitter.module.ts
+++ b/lib/event-emitter.module.ts
@@ -19,7 +19,7 @@ export class EventEmitterModule {
         EventEmitterReadinessWatcher,
         {
           provide: EventEmitter2,
-          useValue: new EventEmitter2(options),
+          useFactory: () => new EventEmitter2(options),
         },
       ],
       exports: [EventEmitter2, EventEmitterReadinessWatcher],

--- a/tests/e2e/module-e2e.spec.ts
+++ b/tests/e2e/module-e2e.spec.ts
@@ -62,6 +62,22 @@ describe('EventEmitterModule - e2e', () => {
     eventSpy.mockRestore();
   });
 
+  it(`event subscribers are separate per each app instance`, async () => {
+    const eventsConsumerRef = app.get(EventsProviderAliasedConsumer);
+    const eventSpy = jest.spyOn(eventsConsumerRef, 'eventPayload', 'set');
+
+    await app.init();
+
+    const module2 = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app2 = module2.createNestApplication();
+    await app2.init();
+
+    expect(eventSpy).toBeCalledTimes(1);
+    eventSpy.mockRestore();
+  });
+
   it(`should emit a "test-event" event to controllers`, async () => {
     const eventsConsumerRef = app.get(EventsControllerConsumer);
     await app.init();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - **not needed**


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently if you create multiple nest app instances referencing the same module that uses `EventEmitterModule.forRoot()`, all app instances will point to the same event emitter instance, causing a single event handler to be subscribed multiple times, instead of just once.

This is caused by the fact that the event emitter instance is created when the module is registered, rather than when an app using that module is initialized.

## Why is the current behaviour annoying?

I have e2e tests that run concurrently, each test building a separate nest app for the same `AppModule`. Recently I have found out that my event subscribers are being called multiple times instead of just once. It took me several hours to find the real cause of the issue - the fact that a single event emitter instance is used for all app instances, even though the module is initialized separartely for each of them.

This fix prevents that.

## What is the new behavior?

Event emitter instance is created separately per each nest app instance importing the event emitter module.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
