### PR TITLE
feat(loader): inherit request context id in request-scoped listeners

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,3 +2,6 @@ import { REQUEST } from '@nestjs/core';
 
 export const EVENT_LISTENER_METADATA = 'EVENT_LISTENER_METADATA';
 export const EVENT_PAYLOAD = REQUEST;
+export const EVENT_EMITTER_MODULE_OPTIONS = Symbol(
+  'EVENT_EMITTER_MODULE_OPTIONS',
+);

--- a/lib/event-emitter.module.ts
+++ b/lib/event-emitter.module.ts
@@ -1,6 +1,7 @@
 import { DynamicModule, Module } from '@nestjs/common';
 import { DiscoveryModule } from '@nestjs/core';
 import { EventEmitter2 } from 'eventemitter2';
+import { EVENT_EMITTER_MODULE_OPTIONS } from './constants';
 import { EventEmitterReadinessWatcher } from './event-emitter-readiness.watcher';
 import { EventSubscribersLoader } from './event-subscribers.loader';
 import { EventsMetadataAccessor } from './events-metadata.accessor';
@@ -20,6 +21,10 @@ export class EventEmitterModule {
         EventSubscribersLoader,
         EventsMetadataAccessor,
         EventEmitterReadinessWatcher,
+        {
+          provide: EVENT_EMITTER_MODULE_OPTIONS,
+          useValue: options ?? {},
+        },
         {
           provide: EventEmitter2,
           useFactory: () => new EventEmitter2(options),

--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -1,8 +1,10 @@
 import {
+  Inject,
   Injectable,
   Logger,
   OnApplicationBootstrap,
   OnApplicationShutdown,
+  Optional,
 } from '@nestjs/common';
 import {
   ContextIdFactory,
@@ -14,9 +16,10 @@ import { Injector } from '@nestjs/core/injector/injector';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { EventEmitter2 } from 'eventemitter2';
+import { EVENT_EMITTER_MODULE_OPTIONS } from './constants';
 import { EventEmitterReadinessWatcher } from './event-emitter-readiness.watcher';
 import { EventsMetadataAccessor } from './events-metadata.accessor';
-import { OnEventOptions } from './interfaces';
+import { EventEmitterModuleOptions, OnEventOptions } from './interfaces';
 import { EventPayloadHost } from './interfaces/event-payload-host.interface';
 
 @Injectable()
@@ -33,6 +36,9 @@ export class EventSubscribersLoader
     private readonly metadataScanner: MetadataScanner,
     private readonly moduleRef: ModuleRef,
     private readonly eventEmitterReadinessWatcher: EventEmitterReadinessWatcher,
+    @Optional()
+    @Inject(EVENT_EMITTER_MODULE_OPTIONS)
+    private readonly options: EventEmitterModuleOptions = {},
   ) {}
 
   onApplicationBootstrap() {
@@ -138,9 +144,15 @@ export class EventSubscribersLoader
       event,
       async (...args: unknown[]) => {
         const request = this.getRequestFromEventPayload(args);
-        const contextId = ContextIdFactory.getByRequest<
-          EventPayloadHost<unknown>
-        >({ payload: request });
+        // When `inheritRequestContextId` is enabled, resolve the context id
+        // directly from the original request so that listeners emitted within
+        // an existing request scope reuse the same dependency tree (#1622).
+        // Otherwise, preserve the original wrapper-based behavior.
+        const contextId = this.options.inheritRequestContextId
+          ? ContextIdFactory.getByRequest(request as Record<string, unknown>)
+          : ContextIdFactory.getByRequest<EventPayloadHost<unknown>>({
+              payload: request,
+            });
 
         this.moduleRef.registerRequestByContextId(request, contextId);
 

--- a/lib/interfaces/event-emitter-options.interface.ts
+++ b/lib/interfaces/event-emitter-options.interface.ts
@@ -13,4 +13,21 @@ export interface EventEmitterModuleOptions extends ConstructorOptions {
    * @default true
    */
   global?: boolean;
+  /**
+   * If "true", request-scoped event listeners resolve the context id
+   * directly from the original request payload using
+   * `ContextIdFactory.getByRequest(request)`. This lets the listener share
+   * the same context id as the originating HTTP request and reuse providers
+   * from the existing dependency tree.
+   *
+   * If "false" (default), the request payload is wrapped as
+   * `{ payload: request }` (`EventPayloadHost`) before resolution, which
+   * preserves the original behavior and resolves the listener context
+   * independently from the originating request context.
+   *
+   * See: https://github.com/nestjs/event-emitter/issues/1622
+   *
+   * @default false
+   */
+  inheritRequestContextId?: boolean;
 }

--- a/tests/e2e/inherit-context-id.spec.ts
+++ b/tests/e2e/inherit-context-id.spec.ts
@@ -1,0 +1,186 @@
+import { vi } from 'vitest';
+import {
+  Controller,
+  INestApplication,
+  Inject,
+  Injectable,
+  Scope,
+} from '@nestjs/common';
+import { ContextIdFactory, createContextId, REQUEST } from '@nestjs/core';
+import { REQUEST_CONTEXT_ID } from '@nestjs/core/router/request/request-constants';
+import { Test } from '@nestjs/testing';
+import { EventEmitter2 } from 'eventemitter2';
+import { EventEmitterModule, OnEvent } from '../../lib';
+
+@Injectable({ scope: Scope.REQUEST })
+class RequestScopedListener {
+  @OnEvent('inherit.test')
+  onTest() {}
+}
+
+@Injectable({ scope: Scope.REQUEST })
+class RequestScopedState {
+  private static nextId = 1;
+
+  static reset() {
+    RequestScopedState.nextId = 1;
+  }
+
+  readonly id = RequestScopedState.nextId++;
+}
+
+@Injectable({ scope: Scope.REQUEST })
+class InheritedContextListener {
+  static records: Array<{
+    listenerRequest: unknown;
+    listenerStateId: number;
+  }> = [];
+
+  static reset() {
+    InheritedContextListener.records = [];
+  }
+
+  constructor(
+    @Inject(REQUEST) private readonly request: unknown,
+    private readonly state: RequestScopedState,
+  ) {}
+
+  @OnEvent('inherit.http')
+  onTest() {
+    InheritedContextListener.records.push({
+      listenerRequest: this.request,
+      listenerStateId: this.state.id,
+    });
+  }
+}
+
+@Controller()
+class InheritedContextController {
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    private readonly state: RequestScopedState,
+  ) {}
+
+  async inherit(request: unknown) {
+    await this.eventEmitter.emitAsync('inherit.http', request);
+    return {
+      controllerStateId: this.state.id,
+      listenerStateId: InheritedContextListener.records[0]?.listenerStateId,
+      sameRequest:
+        InheritedContextListener.records[0]?.listenerRequest === request,
+    };
+  }
+}
+
+describe('EventEmitterModule - inheritRequestContextId', () => {
+  async function createHttpApp(
+    inheritRequestContextId: boolean,
+  ): Promise<INestApplication> {
+    RequestScopedState.reset();
+    InheritedContextListener.reset();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot({ inheritRequestContextId })],
+      controllers: [InheritedContextController],
+      providers: [RequestScopedState, InheritedContextListener],
+    }).compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+    return app;
+  }
+
+  async function callInRequestContext(app: INestApplication) {
+    const request = {};
+    const contextId = createContextId();
+    Object.defineProperty(request, REQUEST_CONTEXT_ID, {
+      value: contextId,
+    });
+    app.registerRequestByContextId(request, contextId);
+
+    const controller = await app.resolve(InheritedContextController, contextId);
+    return controller.inherit(request);
+  }
+
+  it('default (false): wraps request in EventPayloadHost', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot({})],
+      providers: [RequestScopedListener],
+    }).compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    const spy = vi.spyOn(ContextIdFactory, 'getByRequest');
+    const payload = { id: 1 };
+    app.get(EventEmitter2).emit('inherit.test', payload);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toEqual({ payload });
+
+    spy.mockRestore();
+    await app.close();
+  });
+
+  it('inheritRequestContextId=true: forwards original request directly', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot({ inheritRequestContextId: true })],
+      providers: [RequestScopedListener],
+    }).compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    const spy = vi.spyOn(ContextIdFactory, 'getByRequest');
+    const payload = { id: 2 };
+    app.get(EventEmitter2).emit('inherit.test', payload);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toBe(payload);
+
+    spy.mockRestore();
+    await app.close();
+  });
+
+  it('inheritRequestContextId=true: passes original request to context id strategy', async () => {
+    const sharedContextId = { id: Symbol('shared') };
+    const attachSpy = vi.fn(
+      contextId => info => (info.isTreeDurable ? sharedContextId : contextId),
+    );
+    ContextIdFactory.apply({
+      attach: attachSpy,
+    });
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot({ inheritRequestContextId: true })],
+      providers: [RequestScopedListener],
+    }).compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    const payload = { id: 3 };
+    app.get(EventEmitter2).emit('inherit.test', payload);
+
+    expect(attachSpy).toHaveBeenCalled();
+    expect(attachSpy.mock.calls[0][1]).toBe(payload);
+
+    await app.close();
+  });
+
+  it('default (false): creates a separate request-scoped listener context', async () => {
+    const app = await createHttpApp(false);
+    const result = await callInRequestContext(app);
+
+    expect(result.sameRequest).toBe(true);
+    expect(result.listenerStateId).not.toBe(result.controllerStateId);
+
+    await app.close();
+  });
+
+  it('inheritRequestContextId=true: reuses the originating request context', async () => {
+    const app = await createHttpApp(true);
+    const result = await callInRequestContext(app);
+
+    expect(result.sameRequest).toBe(true);
+    expect(result.listenerStateId).toBe(result.controllerStateId);
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (JSDoc on the new option)

## PR Type
- [x] New feature (non-breaking change which adds functionality)

## What is the current behavior?
Closes #1622.

Request-scoped event listeners wrap the payload as `{ payload: request }` before calling `ContextIdFactory.getByRequest`, so the factory can't see the `REQUEST_CONTEXT_ID` on the originating request and resolves the listener context independently. Listeners end up isolated from the request scope that emitted them and can't share request-scoped providers with the rest of the dependency tree.

## What is the new behavior?
Adds an opt-in `inheritRequestContextId` option on `EventEmitterModuleOptions`, default `false`. When `true`, the loader calls `ContextIdFactory.getByRequest(request)` directly so the listener runs in the originating request's context and reuses providers from its dependency tree.

```ts
EventEmitterModule.forRoot({ inheritRequestContextId: true });
```

I went with an opt-in instead of swapping the call unconditionally because existing custom `ContextIdStrategy` implementations may be typed against `EventPayloadHost` and would see a different shape if we changed the default. If you'd rather treat this as a bug fix and flip the default, happy to do that — let me know.

## Tests
29/29 e2e passing (24 existing + 5 new in `tests/e2e/inherit-context-id.spec.ts`):

- default `false` wraps the payload as `{ payload }`
- opt-in `true` forwards the original request directly
- opt-in `true`: a custom `ContextIdStrategy.attach` receives the original request
- default `false`: listener resolves a separate request-scoped context (different `RequestScopedState` instance from the originating controller)
- opt-in `true`: listener and controller share the same request-scoped provider instance

Thanks @ColeStansbury for the detailed write-up on the issue.