### PR TITLE
fix(event-emitter): correctly re-export EventEmitter2

### DIFF
--- a/lib/eventemitter2.ts
+++ b/lib/eventemitter2.ts
@@ -7,5 +7,5 @@ import eventemitter2 from 'eventemitter2';
  * export instead, which is re-exported here so the rest of the codebase can
  * keep using `EventEmitter2` as both a value and a type.
  */
-export const EventEmitter2 = eventemitter2.EventEmitter2;
+export const EventEmitter2 = eventemitter2;
 export type EventEmitter2 = InstanceType<typeof EventEmitter2>;


### PR DESCRIPTION
Use the default export from `eventemitter2` instead of accessing `eventemitter2.EventEmitter2`, which does not exist.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`EventEmitter2` is accessed as `eventemitter2.EventEmitter2`, but `eventemitter2` exports the class as its default export.

## What is the new behavior?

`EventEmitter2` is re-exported from the package's default export, preserving both value and type usage.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This also fixes the resulting `any` type resolution in TypeScript tooling.
