### PR TITLE
Fix EventEmitter2 being typed as any

### DIFF
--- a/lib/eventemitter2.ts
+++ b/lib/eventemitter2.ts
@@ -7,5 +7,5 @@ import eventemitter2 from 'eventemitter2';
  * export instead, which is re-exported here so the rest of the codebase can
  * keep using `EventEmitter2` as both a value and a type.
  */
-export const EventEmitter2 = eventemitter2.EventEmitter2;
+export const EventEmitter2 = eventemitter2;
 export type EventEmitter2 = InstanceType<typeof EventEmitter2>;

--- a/lib/eventemitter2.ts
+++ b/lib/eventemitter2.ts
@@ -1,4 +1,5 @@
 import eventemitter2 from 'eventemitter2';
+import type { EventEmitter2 as EventEmitter2Class } from 'eventemitter2';
 
 /**
  * `eventemitter2` is a CommonJS package, so Node cannot detect its named
@@ -6,6 +7,12 @@ import eventemitter2 from 'eventemitter2';
  * at load time in an ES module. The class has to be read off the default
  * export instead, which is re-exported here so the rest of the codebase can
  * keep using `EventEmitter2` as both a value and a type.
+ *
+ * The explicit annotation matters: without it, the emitted declaration infers
+ * `typeof eventemitter2.EventEmitter2`, which only resolves under
+ * `moduleResolution: "nodenext"`. Consumers on `"bundler"` resolve the default
+ * import to the class itself rather than to the `module.exports` namespace, so
+ * that inferred type collapses to `any` for them.
  */
-export const EventEmitter2 = eventemitter2;
-export type EventEmitter2 = InstanceType<typeof EventEmitter2>;
+export const EventEmitter2: typeof EventEmitter2Class = eventemitter2.EventEmitter2;
+export type EventEmitter2 = EventEmitter2Class;


### PR DESCRIPTION
Annotate the re-exported `EventEmitter2` with the type from `eventemitter2`'s named export, so the emitted declaration no longer depends on default-import interop.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Without an explicit annotation, the emitted declaration infers `typeof eventemitter2.EventEmitter2` from a default import. That resolves only under `moduleResolution: "nodenext"`; under `"bundler"` the default import is the class itself, which has no such static, so the type collapses to `any`:

```ts
import { EventEmitter2 } from '@nestjs/event-emitter'; // any
```

Types-only. The runtime access is correct either way, as the class self-references itself as `EventEmitter.EventEmitter2`.

## What is the new behavior?

The type is anchored to the package's *named* export, which resolves identically under every `moduleResolution`:

```ts
export const EventEmitter2: typeof EventEmitter2Class = eventemitter2.EventEmitter2;
export type EventEmitter2 = EventEmitter2Class;
```

The value still comes through the default import, as the named export is not detectable at runtime for this CommonJS package. Emitted JS is unchanged.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Checked with a consumer under `module: esnext` / `moduleResolution: bundler` holding two deliberate type errors: before, 0 were reported; after, both are. Existing checks pass unchanged.
